### PR TITLE
Fix/dc tmd minor bugs

### DIFF
--- a/flake8-CI.cfg
+++ b/flake8-CI.cfg
@@ -5,7 +5,7 @@ statistics = True
 count = True
 
 # exclude some errors
-ignore = S101, C101, N, W504
+ignore = S101, C101, N, W503
 exclude = .git, build, dist
 per-file-ignores =
     src/*/__init__.py:F401, F403, D104, D400, E501

--- a/setup.cfg
+++ b/setup.cfg
@@ -61,7 +61,7 @@ ignore = WPS433,
          # Found regular name with trailing underscore
          WSP111,
          # Found too short name: X < 2, y < 2
-         W503
+         W503,
          # obsolete, old line break and operator rule
 
 per-file-ignores =
@@ -80,7 +80,6 @@ line_length = 79
 
 skip =
     src/dcTMD/__init__.py,
-    src/dcTMD/_clickextensions.py,
     src/dcTMD/utils/__init__.py,
 
 # setup darglint

--- a/setup.cfg
+++ b/setup.cfg
@@ -64,11 +64,6 @@ ignore = WPS433,
          W503
          # obsolete, old line break and operator rule
 
-
-#WPS410, S101, C101, N, DAR401, DAR402, W504, 
-#    WPS306, WPS352, WPS421F, I, DAR, WPS305, WPS421, WPS110, WPS453, WPS436, 
-#    WPS433, WPS450, WPS434, WPS21, D100, D413, WPS336
-
 per-file-ignores =
     __main__: DAR101
     bootstrapping.py: WPS440

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,21 +31,38 @@ rst-roles = class, func, ref
 rst-directives = todo
 
 # exclude some errors
-ignore = WPS433,   # nested imports
-         WPS436,  # needed to import _typing
-         WPS421,  # print
-         DAR103,  # no types will be provided in docstrings
-         DAR005,  # no types will be provided in docstrings
-         WPS210,  # more than 10 local variables are needed for readability
-         WPS430,  # nested functions
-         WPS305,  # f strings
-         E501,    # more than 79 characters
-         I,       # import errors ignored for now
-         WPS410,  # __all__ is used for now
-         RST306,  # unknown target name
-         DAR401,  # Missing exception(s) in Raises section: -r ValueError
-         WPS120,  # Found regular name with trailing underscore
-         WSP111,  # Found too short name: X < 2, y < 2
+ignore = WPS433,
+         # nested imports
+         WPS436,
+         # needed to import _typing
+         WPS421,
+         # print
+         DAR103,
+         # no types will be provided in docstrings
+         DAR005,
+         # no types will be provided in docstrings
+         WPS210,
+         # more than 10 local variables are needed for readability
+         WPS430,
+         # nested functions
+         WPS305,
+         # f strings
+         E501,
+         # more than 79 characters
+         I,
+         # import errors ignored for now
+         WPS410,
+         # __all__ is used for now
+         RST306,
+         # unknown target name
+         DAR401,
+         # Missing exception(s) in Raises section: -r ValueError
+         WPS120,
+         # Found regular name with trailing underscore
+         WSP111,
+         # Found too short name: X < 2, y < 2
+         W503
+         # obsolete, old line break and operator rule
 
 
 #WPS410, S101, C101, N, DAR401, DAR402, W504, 

--- a/src/dcTMD/__main__.py
+++ b/src/dcTMD/__main__.py
@@ -21,7 +21,7 @@ MODES = ('work', 'force')
     default=MODES[0],
     show_default=True,
     required=True,
-    help='Use either work or force autocovariance function to calculate' +
+    help='Use either work or force autocovariance function to calculate ' +
          'dcTMD quantities.',
 )
 @click.option(
@@ -29,7 +29,7 @@ MODES = ('work', 'force')
     '--file',
     'pullf_files',
     required=True,
-    help='Input: File containing list of all constraint force file names' +
+    help='Input: File containing list of all constraint force file names ' +
     'or glob pattern e.g."*.xvg" to generate a list of all constraint ' +
     'force files using glob.glob()',
 )
@@ -60,7 +60,7 @@ MODES = ('work', 'force')
     default=1,
     show_default=True,
     required=False,
-    help='Striding to reduce size of returned free energy and friction',
+    help='Striding to reduce size of returned free energy and friction.',
 )
 @click.option(
     '-s',
@@ -108,9 +108,11 @@ def main(  # noqa: WPS211, WPS216
 ) -> None:
     """Calculate free energy and friction for given constraint force files.
 
+    \b
     -------------------------
     |         dcTMD         |
     -------------------------
+
     Analysis tools for dissipation-corrected targeted molecular dynamics, which
     is an enhanced sampling method to enforce rare events in biomolecular
     systems. When publishing results gained with this python package, please

--- a/src/dcTMD/__main__.py
+++ b/src/dcTMD/__main__.py
@@ -21,17 +21,17 @@ MODES = ('work', 'force')
     default=MODES[0],
     show_default=True,
     required=True,
-    help='Use either work or force autocovariance function to calculate ' +
-         'dcTMD quantities.',
+    help='Use either work or force autocovariance function to calculate '
+    + 'dcTMD quantities.',
 )
 @click.option(
     '-f',
     '--file',
     'pullf_files',
     required=True,
-    help='Input: File containing list of all constraint force file names ' +
-    'or glob pattern e.g."*.xvg" to generate a list of all constraint ' +
-    'force files using glob.glob()',
+    help='Input: File containing list of all constraint force file names '
+    + 'or glob pattern e.g."*.xvg" to generate a list of all constraint '
+    + 'force files using glob.glob()',
 )
 @click.option(
     '-o',

--- a/src/dcTMD/dcTMD.py
+++ b/src/dcTMD/dcTMD.py
@@ -399,36 +399,6 @@ class WorkEstimator(TransformerMixin, BaseEstimator, SmoothEstimator):
             self.s_friction_ = s_quantity[0, :, 0]
         self.friction_resampled_ = quantity_resampled[:, 0]
 
-    # @beartype
-    # def smooth_friction(
-    #     self,
-    #     sigma: Float,
-    #     mode: Str = 'reflect',
-    # ) -> Float1DArray:
-    #     """Smooth friction with gaussian kernel.
-
-    #     Parameters
-    #     ----------
-    #     sigma:
-    #         standard deviation of gaussian kernel in nm
-    #     mode:
-    #         options: ‘reflect’, ‘constant’, ‘nearest’, ‘mirror’, ‘wrap’
-    #         The mode parameter determines how the input array is
-    #         extended beyond its boundaries. Default is ‘reflect’.
-    #         Behavior for each option see scipy.ndimage.gaussian_filter1d
-
-    #     Returns
-    #     -------
-    #     friction_smooth_ : 1d np.array
-    #         Smoothed friction.
-    #     """
-    #     self.friction_smooth_ = utils.gaussfilter_friction(
-    #         self.friction_,
-    #         self.position_,
-    #         sigma=0.1,
-    #     )
-    #     return self.friction_smooth_
-
 
 class ForceEstimator(TransformerMixin, BaseEstimator, SmoothEstimator):
     """

--- a/src/dcTMD/dcTMD.py
+++ b/src/dcTMD/dcTMD.py
@@ -8,6 +8,7 @@
 __all__ = ['WorkEstimator', 'ForceEstimator']
 
 import numpy as np
+from abc import ABC
 from beartype import beartype
 from beartype.typing import Union, Tuple, Optional
 from sklearn.base import BaseEstimator, TransformerMixin
@@ -24,7 +25,7 @@ from dcTMD._typing import (
 )
 
 
-class SmoothBasisEstimator():
+class _SmoothBasisEstimator(ABC):
     """Class with the smoothing method for `WorkEstimator`, `ForceEstimator`.
     """
     @beartype
@@ -65,7 +66,7 @@ class SmoothBasisEstimator():
             del self.friction_smooth_  # noqa: WPS420
 
 
-class WorkEstimator(TransformerMixin, BaseEstimator, SmoothBasisEstimator):
+class WorkEstimator(TransformerMixin, BaseEstimator, _SmoothBasisEstimator):
     """Class for performing dcTMD analysis on a work set.
 
     Parameters
@@ -408,7 +409,7 @@ class WorkEstimator(TransformerMixin, BaseEstimator, SmoothBasisEstimator):
         self.friction_resampled_ = quantity_resampled[:, 0]
 
 
-class ForceEstimator(TransformerMixin, BaseEstimator, SmoothBasisEstimator):
+class ForceEstimator(TransformerMixin, BaseEstimator, _SmoothBasisEstimator):
     """
     Class for performing dcTMD analysis on a force set.
 

--- a/src/dcTMD/dcTMD.py
+++ b/src/dcTMD/dcTMD.py
@@ -42,7 +42,7 @@ class SmoothEstimator():
             options: ‘reflect’, ‘constant’, ‘nearest’, ‘mirror’, ‘wrap’
             The mode parameter determines how the input array is
             extended beyond its boundaries. Default is ‘reflect’.
-            Behavior for each option see scipy.ndimage.gaussian_filter1d
+            Behavior for each option see scipy.ndimage.gaussian_filter1d.
 
         Returns
         -------
@@ -541,38 +541,6 @@ class ForceEstimator(TransformerMixin, BaseEstimator, SmoothEstimator):
         self.friction_ = friction_[::self.force_set.resolution]
 
         return self.W_mean_, self.W_diss_, self.dG_, self.friction_
-
-    # @beartype
-    # def smooth_friction(
-    #     self,
-    #     sigma: Float,
-    #     mode: Str = 'reflect',
-    # ) -> Float1DArray:
-    #     """
-    #     Smooth friction with gaussian kernel.
-
-    #     Parameters
-    #     ----------
-    #     sigma:
-    #         standard deviation of gaussian kernel in nm
-    #     mode:
-    #         options: ‘reflect’, ‘constant’, ‘nearest’, ‘mirror’, ‘wrap’
-    #         The mode parameter determines how the input array is
-    #         extended beyond its boundaries. Default is ‘reflect’.
-    #         Behavior for each option see scipy.ndimage.gaussian_filter1d
-
-    #     Returns
-    #     -------
-    #     friction_smooth_ : 1d np.array
-    #         Smoothed friction.
-    #     """
-    #     self.friction_smooth_ = utils.gaussfilter_friction(
-    #         self.friction_,
-    #         self.position_,
-    #         sigma=sigma,
-    #         mode=mode,
-    #     )
-    #     return self.friction_smooth_
 
     def memory_kernel(
         self,

--- a/src/dcTMD/dcTMD.py
+++ b/src/dcTMD/dcTMD.py
@@ -3,6 +3,8 @@
 # Copyright (c) 2022, Victor Tänzel, Miriam Jäger
 # All rights reserved.
 """Classes `WorkEstimator`, `ForceEstimator` calculating the dcTMD quantities.
+
+This submodule contains two classes, WorkEstimator and ForceEstimator, which are used for the dcTMD analysis of constraint force time traces. Both class can be used to calculate the mean work, dissipative work, free energy and friction estimate of a set of constraint force time traces. 
 """
 
 __all__ = ['WorkEstimator', 'ForceEstimator']

--- a/src/dcTMD/dcTMD.py
+++ b/src/dcTMD/dcTMD.py
@@ -24,7 +24,7 @@ from dcTMD._typing import (
 
 
 class SmoothBasisEstimator():
-    """Class with the smoothing method for ‘WorkEstimator‘, ‘ForceEstimator‘.
+    """Class with the smoothing method for `WorkEstimator`, `ForceEstimator`.
     """
     @beartype
     def smooth_friction(
@@ -39,9 +39,9 @@ class SmoothBasisEstimator():
         sigma:
             standard deviation of gaussian kernel in nm
         mode:
-            options: ‘reflect’, ‘constant’, ‘nearest’, ‘mirror’, ‘wrap’
+            options: `reflect`, `constant`, `nearest`,`mirror`, `wrap`
             The mode parameter determines how the input array is
-            extended beyond its boundaries. Default is ‘reflect’.
+            extended beyond its boundaries. Default is `reflect`.
             Behavior for each option see scipy.ndimage.gaussian_filter1d.
 
         Returns
@@ -85,22 +85,22 @@ class WorkEstimator(TransformerMixin, BaseEstimator, SmoothBasisEstimator):
         bootstrapping errors are calculated.
     s_W_mean_ :
         Bootstrapping error of the mean work. Calculated via
-        estimate_free_energy_errors().
+        `estimate_free_energy_errors()`.
     s_W_diss_ :
         Bootstrapping error of the dissipative work. Calculated via
-        estimate_free_energy_errors().
+        `estimate_free_energy_errors()`.
     s_dG_ :
         Bootstrapping error of the free energy estimate. Calculated via
-        estimate_free_energy_errors().
+        `estimate_free_energy_errors()`.
     W_mean_resampled_ :
         Resampled mean work, needed to inspect its distribution. Calculated
-        via estimate_free_energy_errors().
+        via `estimate_free_energy_errors()`.
     W_diss_resampled_ :
         Resampled dissipative work, needed to inspect its distribution.
-        Calculated via estimate_free_energy_errors().
+        Calculated via `estimate_free_energy_errors()`.
     dG_resampled_ :
         Resampled free energy estimate, needed to inspect its distribution.
-        Calculated via estimate_free_energy_errors().
+        Calculated via `estimate_free_energy_errors()`.
 
     Examples
     --------
@@ -485,7 +485,7 @@ class ForceEstimator(TransformerMixin, BaseEstimator, SmoothBasisEstimator):
         self,
     ) -> Tuple[Float1DArray, Float1DArray, Float1DArray, Float1DArray]:
         """
-        Estimate free energy and friction from force auto corrleation.
+        Estimate free energy and friction from force auto correlation.
 
         Returns
         -------
@@ -521,7 +521,6 @@ class ForceEstimator(TransformerMixin, BaseEstimator, SmoothBasisEstimator):
         )
         friction_ = np.mean(intcorr, axis=0) / RT
 
-        print('Calculating dissipative work...')
         W_mean_ = cumulative_trapezoid(
             force_mean,
             self.force_set.position_,

--- a/src/dcTMD/dcTMD.py
+++ b/src/dcTMD/dcTMD.py
@@ -7,7 +7,6 @@
 __all__ = ['WorkEstimator', 'ForceEstimator']
 
 import numpy as np
-from abc import ABC, abstractmethod
 from beartype import beartype
 from beartype.typing import Union, Tuple, Optional
 from sklearn.base import BaseEstimator, TransformerMixin
@@ -25,7 +24,7 @@ from dcTMD._typing import (
 
 
 class SmoothEstimator():
-    """Abstract class providing the smoothing method.
+    """Class with the smoothing method for `WorkEstimator`, `ForceEstimator`.
     """
     @beartype
     def smooth_friction(
@@ -573,37 +572,37 @@ class ForceEstimator(TransformerMixin, BaseEstimator, SmoothEstimator):
 
         return self.W_mean_, self.W_diss_, self.dG_, self.friction_
 
-    @beartype
-    def smooth_friction(
-        self,
-        sigma: Float,
-        mode: Str = 'reflect',
-    ) -> Float1DArray:
-        """
-        Smooth friction with gaussian kernel.
+    # @beartype
+    # def smooth_friction(
+    #     self,
+    #     sigma: Float,
+    #     mode: Str = 'reflect',
+    # ) -> Float1DArray:
+    #     """
+    #     Smooth friction with gaussian kernel.
 
-        Parameters
-        ----------
-        sigma:
-            standard deviation of gaussian kernel in nm
-        mode:
-            options: ‘reflect’, ‘constant’, ‘nearest’, ‘mirror’, ‘wrap’
-            The mode parameter determines how the input array is
-            extended beyond its boundaries. Default is ‘reflect’.
-            Behavior for each option see scipy.ndimage.gaussian_filter1d
+    #     Parameters
+    #     ----------
+    #     sigma:
+    #         standard deviation of gaussian kernel in nm
+    #     mode:
+    #         options: ‘reflect’, ‘constant’, ‘nearest’, ‘mirror’, ‘wrap’
+    #         The mode parameter determines how the input array is
+    #         extended beyond its boundaries. Default is ‘reflect’.
+    #         Behavior for each option see scipy.ndimage.gaussian_filter1d
 
-        Returns
-        -------
-        friction_smooth_ : 1d np.array
-            Smoothed friction.
-        """
-        self.friction_smooth_ = utils.gaussfilter_friction(
-            self.friction_,
-            self.position_,
-            sigma=sigma,
-            mode=mode,
-        )
-        return self.friction_smooth_
+    #     Returns
+    #     -------
+    #     friction_smooth_ : 1d np.array
+    #         Smoothed friction.
+    #     """
+    #     self.friction_smooth_ = utils.gaussfilter_friction(
+    #         self.friction_,
+    #         self.position_,
+    #         sigma=sigma,
+    #         mode=mode,
+    #     )
+    #     return self.friction_smooth_
 
     def memory_kernel(
         self,

--- a/src/dcTMD/dcTMD.py
+++ b/src/dcTMD/dcTMD.py
@@ -4,7 +4,10 @@
 # All rights reserved.
 """Classes `WorkEstimator`, `ForceEstimator` calculating the dcTMD quantities.
 
-This submodule contains two classes, WorkEstimator and ForceEstimator, which are used for the dcTMD analysis of constraint force time traces. Both class can be used to calculate the mean work, dissipative work, free energy and friction estimate of a set of constraint force time traces. 
+This submodule contains two classes, WorkEstimator and ForceEstimator, which
+are used for the dcTMD analysis of constraint force time traces. Both class can
+be used to calculate the mean work, dissipative work, free energy and friction
+estimate of a set of constraint force time traces.
 """
 
 __all__ = ['WorkEstimator', 'ForceEstimator']

--- a/src/dcTMD/dcTMD.py
+++ b/src/dcTMD/dcTMD.py
@@ -94,26 +94,33 @@ class WorkEstimator(TransformerMixin, BaseEstimator, _SmoothBasisEstimator):
     friction_:
         Friction factor in kJ/mol/(nm^2/ps).
     mode_ :
-        Parameter of [WorkEstimator.estimate_free_energy_errors][dcTMD.dcTMD.WorkEstimator.estimate_free_energy_errors]. Decides how the
-        bootstrapping errors are calculated.
+        Parameter of [WorkEstimator.estimate_free_energy_errors][dcTMD.dcTMD.\
+WorkEstimator.estimate_free_energy_errors]. Decides how the bootstrapping
+        errors are calculated.
     s_W_mean_ :
-        Bootstrapping error of the mean work. Calculated via
-        [WorkEstimator.estimate_free_energy_errors][dcTMD.dcTMD.WorkEstimator.estimate_free_energy_errors].
+        Bootstrapping error of the mean work. Calculated via [WorkEstimator.\
+estimate_free_energy_errors][dcTMD.dcTMD.WorkEstimator.\
+estimate_free_energy_errors].
     s_W_diss_ :
         Bootstrapping error of the dissipative work. Calculated via
-        [WorkEstimator.estimate_free_energy_errors][dcTMD.dcTMD.WorkEstimator.estimate_free_energy_errors].
+        [WorkEstimator.estimate_free_energy_errors][dcTMD.dcTMD.WorkEstimator.\
+estimate_free_energy_errors].
     s_dG_ :
         Bootstrapping error of the free energy estimate. Calculated via
-        [WorkEstimator.estimate_free_energy_errors][dcTMD.dcTMD.WorkEstimator.estimate_free_energy_errors].
+        [WorkEstimator.estimate_free_energy_errors][dcTMD.dcTMD.WorkEstimator.\
+estimate_free_energy_errors].
     W_mean_resampled_ :
         Resampled mean work, needed to inspect its distribution. Calculated
-        via [WorkEstimator.estimate_free_energy_errors][dcTMD.dcTMD.WorkEstimator.estimate_free_energy_errors].
+        via [WorkEstimator.estimate_free_energy_errors][dcTMD.dcTMD.\
+WorkEstimator.estimate_free_energy_errors].
     W_diss_resampled_ :
         Resampled dissipative work, needed to inspect its distribution.
-        Calculated via [WorkEstimator.estimate_free_energy_errors][dcTMD.dcTMD.WorkEstimator.estimate_free_energy_errors].
+        Calculated via [WorkEstimator.estimate_free_energy_errors][dcTMD.\
+dcTMD.WorkEstimator.estimate_free_energy_errors].
     dG_resampled_ :
         Resampled free energy estimate, needed to inspect its distribution.
-        Calculated via [WorkEstimator.estimate_free_energy_errors][dcTMD.dcTMD.WorkEstimator.estimate_free_energy_errors].
+        Calculated via [WorkEstimator.estimate_free_energy_errors][dcTMD.\
+dcTMD.WorkEstimator.estimate_free_energy_errors].
 
     Examples
     --------
@@ -236,7 +243,8 @@ class WorkEstimator(TransformerMixin, BaseEstimator, _SmoothBasisEstimator):
 
         Bootstrapping errors are calculated for the free energy estimate and
         the related quantities mean and dissipative work. Return matches the
-        one of [WorkEstimator.estimate_free_energy][dcTMD.dcTMD.WorkEstimator.estimate_free_energy].
+        one of [WorkEstimator.estimate_free_energy][dcTMD.dcTMD.WorkEstimator.\
+estimate_free_energy].
 
         Parameters
         ----------
@@ -309,7 +317,7 @@ class WorkEstimator(TransformerMixin, BaseEstimator, _SmoothBasisEstimator):
         """
         Estimate bootstrapping errors for the friction.
 
-        Besides calculating dcTMD quantitites to the class, this function
+        Besides calculating dcTMD quantities to the class, this function
         is also called from the bootstrapping routine. In the latter case,
         which comes with a passed `W_diss` parameter, attributes should not
         be overwritten.
@@ -357,7 +365,8 @@ class WorkEstimator(TransformerMixin, BaseEstimator, _SmoothBasisEstimator):
 
         Bootstrapping errors are calculated for the free energy estimate and
         the related quantities mean and dissipative work. Return matches the
-        one of [WorkEstimator.estimate_free_energy][dcTMD.dcTMD.WorkEstimator.estimate_free_energy].
+        one of [WorkEstimator.estimate_free_energy][dcTMD.dcTMD.WorkEstimator.\
+estimate_free_energy].
 
         Parameters
         ----------

--- a/src/dcTMD/dcTMD.py
+++ b/src/dcTMD/dcTMD.py
@@ -58,6 +58,12 @@ class SmoothBasisEstimator():
         )
         return self.friction_smooth_
 
+    @beartype
+    def _reset(self) -> None:
+        """Reset friction_smooth_ attribute."""
+        if hasattr(self, 'friction_smooth_'):  # noqa: WPS421
+            del self.friction_smooth_  # noqa: WPS420
+
 
 class WorkEstimator(TransformerMixin, BaseEstimator, SmoothBasisEstimator):
     """Class for performing dcTMD analysis on a work set.

--- a/src/dcTMD/dcTMD.py
+++ b/src/dcTMD/dcTMD.py
@@ -23,7 +23,7 @@ from dcTMD._typing import (
 )
 
 
-class SmoothEstimator():
+class SmoothBasisEstimator():
     """Class with the smoothing method for ‘WorkEstimator‘, ‘ForceEstimator‘.
     """
     @beartype
@@ -58,7 +58,7 @@ class SmoothEstimator():
         return self.friction_smooth_
 
 
-class WorkEstimator(TransformerMixin, BaseEstimator, SmoothEstimator):
+class WorkEstimator(TransformerMixin, BaseEstimator, SmoothBasisEstimator):
     """Class for performing dcTMD analysis on a work set.
 
     Parameters
@@ -400,7 +400,7 @@ class WorkEstimator(TransformerMixin, BaseEstimator, SmoothEstimator):
         self.friction_resampled_ = quantity_resampled[:, 0]
 
 
-class ForceEstimator(TransformerMixin, BaseEstimator, SmoothEstimator):
+class ForceEstimator(TransformerMixin, BaseEstimator, SmoothBasisEstimator):
     """
     Class for performing dcTMD analysis on a force set.
 

--- a/src/dcTMD/dcTMD.py
+++ b/src/dcTMD/dcTMD.py
@@ -474,6 +474,7 @@ class ForceEstimator(TransformerMixin, BaseEstimator, SmoothBasisEstimator):
         self :
             Fitted estimator.
         """
+        self._reset()
         self.force_set = force_set
         self.names_ = force_set.names_
         self.estimate_free_energy_friction()

--- a/src/dcTMD/dcTMD.py
+++ b/src/dcTMD/dcTMD.py
@@ -2,7 +2,8 @@
 # MIT License
 # Copyright (c) 2022, Victor Tänzel, Miriam Jäger
 # All rights reserved.
-"""Classes calculating the dcTMD quantities."""
+"""Classes `WorkEstimator`, `ForceEstimator` calculating the dcTMD quantities.
+"""
 
 __all__ = ['WorkEstimator', 'ForceEstimator']
 

--- a/src/dcTMD/dcTMD.py
+++ b/src/dcTMD/dcTMD.py
@@ -151,6 +151,7 @@ class WorkEstimator(TransformerMixin, BaseEstimator, SmoothBasisEstimator):
         self :
             Fitted estimator.
         """
+        self._reset()
         self.work_set = work_set
         self.position_ = work_set.position_
         self.names_ = work_set.names_

--- a/src/dcTMD/dcTMD.py
+++ b/src/dcTMD/dcTMD.py
@@ -94,26 +94,26 @@ class WorkEstimator(TransformerMixin, BaseEstimator, _SmoothBasisEstimator):
     friction_:
         Friction factor in kJ/mol/(nm^2/ps).
     mode_ :
-        Parameter of estimate_free_energy_errors(). Decides how the
+        Parameter of [WorkEstimator.estimate_free_energy_errors][dcTMD.dcTMD.WorkEstimator.estimate_free_energy_errors]. Decides how the
         bootstrapping errors are calculated.
     s_W_mean_ :
         Bootstrapping error of the mean work. Calculated via
-        `estimate_free_energy_errors()`.
+        [WorkEstimator.estimate_free_energy_errors][dcTMD.dcTMD.WorkEstimator.estimate_free_energy_errors].
     s_W_diss_ :
         Bootstrapping error of the dissipative work. Calculated via
-        `estimate_free_energy_errors()`.
+        [WorkEstimator.estimate_free_energy_errors][dcTMD.dcTMD.WorkEstimator.estimate_free_energy_errors].
     s_dG_ :
         Bootstrapping error of the free energy estimate. Calculated via
-        `estimate_free_energy_errors()`.
+        [WorkEstimator.estimate_free_energy_errors][dcTMD.dcTMD.WorkEstimator.estimate_free_energy_errors].
     W_mean_resampled_ :
         Resampled mean work, needed to inspect its distribution. Calculated
-        via `estimate_free_energy_errors()`.
+        via [WorkEstimator.estimate_free_energy_errors][dcTMD.dcTMD.WorkEstimator.estimate_free_energy_errors].
     W_diss_resampled_ :
         Resampled dissipative work, needed to inspect its distribution.
-        Calculated via `estimate_free_energy_errors()`.
+        Calculated via [WorkEstimator.estimate_free_energy_errors][dcTMD.dcTMD.WorkEstimator.estimate_free_energy_errors].
     dG_resampled_ :
         Resampled free energy estimate, needed to inspect its distribution.
-        Calculated via `estimate_free_energy_errors()`.
+        Calculated via [WorkEstimator.estimate_free_energy_errors][dcTMD.dcTMD.WorkEstimator.estimate_free_energy_errors].
 
     Examples
     --------
@@ -236,7 +236,7 @@ class WorkEstimator(TransformerMixin, BaseEstimator, _SmoothBasisEstimator):
 
         Bootstrapping errors are calculated for the free energy estimate and
         the related quantities mean and dissipative work. Return matches the
-        one of [dcTMD.dcTMD.WorkEstimator.estimate_free_energy][].
+        one of [WorkEstimator.estimate_free_energy][dcTMD.dcTMD.WorkEstimator.estimate_free_energy].
 
         Parameters
         ----------
@@ -357,7 +357,7 @@ class WorkEstimator(TransformerMixin, BaseEstimator, _SmoothBasisEstimator):
 
         Bootstrapping errors are calculated for the free energy estimate and
         the related quantities mean and dissipative work. Return matches the
-        one of estimate_free_energy().
+        one of [WorkEstimator.estimate_free_energy][dcTMD.dcTMD.WorkEstimator.estimate_free_energy].
 
         Parameters
         ----------
@@ -568,12 +568,12 @@ class ForceEstimator(TransformerMixin, BaseEstimator, _SmoothBasisEstimator):
 
         Parameters
         ----------
-        x_indices : np.ndarray
+        x_indices :
             Indices at which memory kernel is calculated.
 
         Returns
         -------
-        corr_set : np.ndarray
+        corr_set :
             shape: (len(X), length_data)
             NaN are set to zero
         """

--- a/src/dcTMD/dcTMD.py
+++ b/src/dcTMD/dcTMD.py
@@ -24,7 +24,7 @@ from dcTMD._typing import (
 
 
 class SmoothEstimator():
-    """Class with the smoothing method for `WorkEstimator`, `ForceEstimator`.
+    """Class with the smoothing method for ‘WorkEstimator‘, ‘ForceEstimator‘.
     """
     @beartype
     def smooth_friction(

--- a/src/dcTMD/utils/plotting.py
+++ b/src/dcTMD/utils/plotting.py
@@ -38,7 +38,7 @@ def fig_sizehalfA4width():
 
 
 def plot_dcTMD_results(x, workestimator, friction):
-    """Plot dcTMD results in two subplots."""
+    """Plot dcTMD results overview in two subplots."""
     fig, axs = plt.subplots(ncols=1,
                             nrows=2,
                             sharex=True,
@@ -56,7 +56,7 @@ def plot_dcTMD_results(x, workestimator, friction):
 
 
 def plot_dG_Wdiss(x, workestimator, ax):
-    """Plot free energy, dissipative work and mean work vs x."""
+    """Plot free energy, dissipative work and mean work against position."""
     ax.plot(x, workestimator.dG_, label=r'$\Delta G$')
     ax.plot(x, workestimator.W_mean_, label=r'W$_{\mathrm{mean}}$')
     ax.plot(x, workestimator.W_diss_, label=r'W$_{\mathrm{diss}}$')
@@ -67,7 +67,7 @@ def plot_dG_Wdiss(x, workestimator, ax):
 
 
 def plot_Gamma(x, friction, ax, label=None):
-    """Plot friction vs x."""
+    """Plot friction factor against position."""
     ax.plot(x, friction, label=rf"{label}")
     ax.set(xlabel=r'position $x$ [nm]',
            ylabel=r'$\Gamma$ [kJ/mol/(nm$^2$/ps)]',
@@ -76,7 +76,7 @@ def plot_Gamma(x, friction, ax, label=None):
 
 
 def plot_dG(x, dG, ax, label=None):
-    """Plot dG vs x."""
+    """Plot free energy against position."""
     ax.plot(x, dG, label=rf"{label}")
     ax.set(xlabel=r'position $x$ [nm]',
            ylabel=r'$\Delta G$ [kJ/mol]',
@@ -85,7 +85,7 @@ def plot_dG(x, dG, ax, label=None):
 
 
 def plot_worklines(x, workset, ax):
-    """Plot work values of trajectories individually."""
+    """Plot work of trajectories individually."""
     for w in workset:
         ax.plot(x, w, color='#777', alpha=.5, lw=.5)
 
@@ -125,7 +125,7 @@ def plot_histo_normaldist(data, ax, color='blue', label=None):
 def plot_worknormalitychecks(x, workset, index, colors=None):
     """Plots the work values of trajectories individually.
 
-    And adds histograms and normality plots for the indices given in index.
+    Also adds histograms and normality plots for the indices given in `index`.
     """
     fig, axs = plt.subplots(ncols=3,
                             nrows=1,
@@ -140,7 +140,7 @@ def plot_worknormalitychecks(x, workset, index, colors=None):
 
     for j, idx in enumerate(index):
         data = workset[:, idx].flatten()
-        axs[1].set_title('Histrogram at x')
+        axs[1].set_title(r'Histogram at $x$')
         plot_histo_normaldist(data, axs[1], colors[j])
         axs[0].axvline(x[idx],
                        color=colors[j],
@@ -150,7 +150,7 @@ def plot_worknormalitychecks(x, workset, index, colors=None):
 
         probplot(data, plot=axs[2], fit=True)
         axs[2].get_lines()[j * 2].set_color(colors[j])
-        axs[2].set_title('Normality Plot')
+        axs[2].set_title('Normality plot')
 
     axs[0].legend()
     plt.tight_layout()

--- a/src/dcTMD/utils/plotting.py
+++ b/src/dcTMD/utils/plotting.py
@@ -134,8 +134,7 @@ def plot_worknormalitychecks(x, workset, index, colors=None):
     plot_worklines(x, workset, axs[0])
 
     if not colors:
-        import matplotlib as mpl
-        cmap = mpl.colormaps['Dark2']
+        cmap = plt.get_cmap('Dark2')
         colors = cmap.colors
 
     for j, idx in enumerate(index):

--- a/src/dcTMD/utils/plotting.py
+++ b/src/dcTMD/utils/plotting.py
@@ -134,8 +134,8 @@ def plot_worknormalitychecks(x, workset, index, colors=None):
     plot_worklines(x, workset, axs[0])
 
     if not colors:
-        from matplotlib.cm import get_cmap
-        cmap = get_cmap('Dark2')
+        import matplotlib as mpl
+        cmap = mpl.colormaps['Dark2']
         colors = cmap.colors
 
     for j, idx in enumerate(index):

--- a/tests/test_dcTMD.py
+++ b/tests/test_dcTMD.py
@@ -13,7 +13,7 @@ VERBOSE = True
 TEMPERATURE = 300
 INDICES = np.array([1, 3, 5])
 SIGMA = 0.1
-MODE = 'reflect'
+MODE = 'nearest'
 HERE = dirname(__file__)
 TEST_FILE_DIR = join(HERE, 'testdata')
 
@@ -46,24 +46,29 @@ def assert_estimator_equality(estimator1, estimator2):
     np.testing.assert_almost_equal(
         estimator1.W_mean_,
         estimator2.W_mean_,
+        err_msg='Mean work test failed.',
     )
     np.testing.assert_almost_equal(
         estimator1.W_diss_,
         estimator2.W_diss_,
+        err_msg='Dissipative work test failed.',
     )
     np.testing.assert_almost_equal(
         estimator1.dG_,
         estimator2.dG_,
+        err_msg='Free energy test failed.',
     )
     np.testing.assert_almost_equal(
         estimator1.friction_,
         estimator2.friction_,
         decimal=6,
+        err_msg='Friction test failed.',
     )
     np.testing.assert_almost_equal(
         estimator1.friction_smooth_,
         estimator2.friction_smooth_,
         decimal=6,
+        err_msg='Smoothed friction test failed.',
     )
 
 

--- a/tests/test_dcTMD.py
+++ b/tests/test_dcTMD.py
@@ -39,7 +39,7 @@ def ref_forceestimator(scope="session"):
 
 
 def assert_estimator_equality(estimator1, estimator2):
-    """Compare to WorkEstimator or ForceEstimator instances via asserts."""
+    """Compare two WorkEstimator or ForceEstimator instances via asserts."""
     assert type(estimator1) is type(estimator2)
     assert estimator1.temperature == estimator2.temperature
     assert estimator1.verbose == estimator2.verbose
@@ -82,3 +82,36 @@ def test_ForceEstimator(ref_forceestimator):
     forceestimator_name = f'{TEST_FILE_DIR}/forceestimator'
     estimator = storing.load(filename=forceestimator_name)
     assert_estimator_equality(estimator, ref_forceestimator)
+
+
+def test_estimator_reset():
+    """Test if _reset is called by fit to delete friction_smooth_.
+
+    When refitting a WorkEstimator with a new WorkSet, many attributes are
+    calculated directly by the fit function. However, the smoothed friction
+    is not directly calculated. As it no longer corresponds to the fitted
+    WorkSet, it is deleted. This is what is tested for, here.
+    """
+    # WorkSet
+    workset_name = f'{TEST_FILE_DIR}/workset'
+    workset = storing.load(filename=workset_name)
+    estimator = dcTMD.WorkEstimator(temperature=TEMPERATURE)
+    estimator.fit(workset)
+    estimator.smooth_friction(SIGMA, MODE)
+    # Check if attribute exists
+    assert hasattr(estimator, 'friction_smooth_')  # noqa: WPS421
+    estimator.fit(workset)
+    # Check if attribute no longer exists
+    assert not hasattr(estimator, 'friction_smooth_')  # noqa: WPS421
+
+    # ForceSet
+    forceset_name = f'{TEST_FILE_DIR}/forceset'
+    forceset = storing.load(filename=forceset_name)
+    estimator = dcTMD.ForceEstimator(temperature=TEMPERATURE)
+    estimator.fit(forceset)
+    estimator.smooth_friction(SIGMA, MODE)
+    # Check if attribute exists
+    assert hasattr(estimator, 'friction_smooth_')  # noqa: WPS421
+    estimator.fit(forceset)
+    # Check if attribute no longer exists
+    assert not hasattr(estimator, 'friction_smooth_')  # noqa: WPS421

--- a/tests/test_dcTMD.py
+++ b/tests/test_dcTMD.py
@@ -22,7 +22,6 @@ TEST_FILE_DIR = join(HERE, 'testdata')
 def ref_workestimator(scope="session"):
     workset_name = f'{TEST_FILE_DIR}/workset'
     workset = storing.load(filename=workset_name)
-    print(workset)
     estimator = dcTMD.WorkEstimator(temperature=TEMPERATURE)
     estimator.fit(workset)
     estimator.smooth_friction(SIGMA, MODE)

--- a/tests/test_dcTMD.py
+++ b/tests/test_dcTMD.py
@@ -84,7 +84,12 @@ def test_ForceEstimator(ref_forceestimator):
     assert_estimator_equality(estimator, ref_forceestimator)
 
 
-def test_estimator_reset():
+@pytest.mark.parametrize(
+    "set, Estimator",
+    [('workset', dcTMD.WorkEstimator),
+     ('forceset', dcTMD.ForceEstimator)],
+)
+def test_estimator_reset(set, Estimator):
     """Test if _reset is called by fit to delete friction_smooth_.
 
     When refitting a WorkEstimator with a new WorkSet, many attributes are
@@ -92,26 +97,37 @@ def test_estimator_reset():
     is not directly calculated. As it no longer corresponds to the fitted
     WorkSet, it is deleted. This is what is tested for, here.
     """
-    # WorkSet
-    workset_name = f'{TEST_FILE_DIR}/workset'
-    workset = storing.load(filename=workset_name)
-    estimator = dcTMD.WorkEstimator(temperature=TEMPERATURE)
-    estimator.fit(workset)
+    set_name = f'{TEST_FILE_DIR}/{set}'
+    set = storing.load(filename=set_name)
+    estimator = Estimator(temperature=TEMPERATURE)
+    estimator.fit(set)
     estimator.smooth_friction(SIGMA, MODE)
     # Check if attribute exists
     assert hasattr(estimator, 'friction_smooth_')  # noqa: WPS421
-    estimator.fit(workset)
+    estimator.fit(set)
     # Check if attribute no longer exists
     assert not hasattr(estimator, 'friction_smooth_')  # noqa: WPS421
 
-    # ForceSet
-    forceset_name = f'{TEST_FILE_DIR}/forceset'
-    forceset = storing.load(filename=forceset_name)
-    estimator = dcTMD.ForceEstimator(temperature=TEMPERATURE)
-    estimator.fit(forceset)
-    estimator.smooth_friction(SIGMA, MODE)
-    # Check if attribute exists
-    assert hasattr(estimator, 'friction_smooth_')  # noqa: WPS421
-    estimator.fit(forceset)
-    # Check if attribute no longer exists
-    assert not hasattr(estimator, 'friction_smooth_')  # noqa: WPS421
+    # # WorkSet
+    # workset_name = f'{TEST_FILE_DIR}/workset'
+    # workset = storing.load(filename=workset_name)
+    # estimator = dcTMD.WorkEstimator(temperature=TEMPERATURE)
+    # estimator.fit(workset)
+    # estimator.smooth_friction(SIGMA, MODE)
+    # # Check if attribute exists
+    # assert hasattr(estimator, 'friction_smooth_')  # noqa: WPS421
+    # estimator.fit(workset)
+    # # Check if attribute no longer exists
+    # assert not hasattr(estimator, 'friction_smooth_')  # noqa: WPS421
+
+    # # ForceSet
+    # forceset_name = f'{TEST_FILE_DIR}/forceset'
+    # forceset = storing.load(filename=forceset_name)
+    # estimator = dcTMD.ForceEstimator(temperature=TEMPERATURE)
+    # estimator.fit(forceset)
+    # estimator.smooth_friction(SIGMA, MODE)
+    # # Check if attribute exists
+    # assert hasattr(estimator, 'friction_smooth_')  # noqa: WPS421
+    # estimator.fit(forceset)
+    # # Check if attribute no longer exists
+    # assert not hasattr(estimator, 'friction_smooth_')  # noqa: WPS421

--- a/tests/test_dcTMD.py
+++ b/tests/test_dcTMD.py
@@ -95,7 +95,8 @@ def test_estimator_reset(set, Estimator):
     When refitting a WorkEstimator with a new WorkSet, many attributes are
     calculated directly by the fit function. However, the smoothed friction
     is not directly calculated. As it no longer corresponds to the fitted
-    WorkSet, it is deleted. This is what is tested for, here.
+    WorkSet, it is deleted. This is what is tested for, here, and analogously
+    for the ForceEstimator."
     """
     set_name = f'{TEST_FILE_DIR}/{set}'
     set = storing.load(filename=set_name)
@@ -107,27 +108,3 @@ def test_estimator_reset(set, Estimator):
     estimator.fit(set)
     # Check if attribute no longer exists
     assert not hasattr(estimator, 'friction_smooth_')  # noqa: WPS421
-
-    # # WorkSet
-    # workset_name = f'{TEST_FILE_DIR}/workset'
-    # workset = storing.load(filename=workset_name)
-    # estimator = dcTMD.WorkEstimator(temperature=TEMPERATURE)
-    # estimator.fit(workset)
-    # estimator.smooth_friction(SIGMA, MODE)
-    # # Check if attribute exists
-    # assert hasattr(estimator, 'friction_smooth_')  # noqa: WPS421
-    # estimator.fit(workset)
-    # # Check if attribute no longer exists
-    # assert not hasattr(estimator, 'friction_smooth_')  # noqa: WPS421
-
-    # # ForceSet
-    # forceset_name = f'{TEST_FILE_DIR}/forceset'
-    # forceset = storing.load(filename=forceset_name)
-    # estimator = dcTMD.ForceEstimator(temperature=TEMPERATURE)
-    # estimator.fit(forceset)
-    # estimator.smooth_friction(SIGMA, MODE)
-    # # Check if attribute exists
-    # assert hasattr(estimator, 'friction_smooth_')  # noqa: WPS421
-    # estimator.fit(forceset)
-    # # Check if attribute no longer exists
-    # assert not hasattr(estimator, 'friction_smooth_')  # noqa: WPS421


### PR DESCRIPTION
Contrary to the title, this branch contains minor fixes in terms of spelling, documentation as well as a proper input handling for the friction smoothing function. Before, 'mode' and 'sigma' were not passed to scipy.ndimage.gaussian_filter. Fixing this made the tests fail. The tests were adapted. 

Secondly, smoothing was so far contained in WorkEstimator and ForceEstimator. To avoid code redundancy, the SmoothBasisEstimator was introduced, which provides the smoothing method.