### PR TITLE
Add environment files

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,3 @@
+include requirements.txt
 include extra-requirements.txt
+include environment.yml

--- a/README.md
+++ b/README.md
@@ -63,20 +63,37 @@ We kindly ask you to cite these articles in case you use this software package f
 
 ## Installation
 `dcTMD` is available on **PyPI** and **conda-forge**.
-#### Install with pip
+
+#### From PyPI
 ```bash
 pip install dcTMD
 ```
 PyPI project page: [https://pypi.org/project/dcTMD/](https://pypi.org/project/dcTMD/)
-#### Install with conda
+
+#### From conda-forge
 ```bash
 conda install conda-forge::dctmd
 ```
 Conda-forge package page:
 [https://anaconda.org/conda-forge/dcTMD](https://anaconda.org/conda-forge/dcTMD)
-#### Install from GitHub
+
+#### From GitHub
 ```bash
 python3 -m pip install git+ssh://git@github.com/moldyn/dcTMD.git
+```
+
+### Local development environment
+The runtime dependencies are listed in [requirements.txt](requirements.txt) and [environment.yml](environment.yml). For a local checkout, install them with:
+
+```bash
+python3 -m pip install -r requirements.txt
+```
+
+For conda users, create the environment with:
+
+```bash
+conda env create -f environment.yml
+conda activate dcTMD
 ```
 
 ## Usage

--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,16 @@
+# Development environment for dcTMD.
+#   conda env create -f environment.yml
+#   conda activate dcTMD
+name: dcTMD
+channels:
+  - conda-forge
+dependencies:
+  - python>=3.9
+  - numpy>=1.21.0
+  - scipy
+  - scikit-learn
+  - beartype>=0.10.4
+  - tqdm
+  - click>=7.0.0
+  - matplotlib>=3.7
+  - pip

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,9 @@
+# Runtime dependencies of dcTMD.
+# Install with: python3 -m pip install -r requirements.txt
+numpy>=1.21.0
+scipy
+scikit-learn
+beartype>=0.10.4
+tqdm
+click>=7.0.0
+matplotlib>=3.7

--- a/setup.py
+++ b/setup.py
@@ -4,6 +4,16 @@ from collections import defaultdict
 from setuptools import setup, find_packages
 
 
+def get_requirements(path):
+    """Parse runtime requirements file."""
+    with open(path) as depfile:
+        return [
+            line.strip()
+            for line in depfile
+            if line.strip() and not line.startswith('#')
+        ]
+
+
 def get_extra_requirements(path, add_all=True):
     """Parse extra-requirements file."""
     with open(path) as depfile:
@@ -70,16 +80,8 @@ setup(
     packages=find_packages(where='src'),
     include_package_data=True,
     python_requires='>=3.9',
-    install_requires=[
-        'numpy>=1.21.0',
-        'scikit-learn',
-        'beartype>=0.10.4',
-        'scipy',
-        'tqdm',
-        'click>=7.0.0',
-        'matplotlib>=3.7',
-    ],
-    extras_require=get_extra_requirements('extra-requirements.txt'),
+    install_requires=get_requirements(HERE / 'requirements.txt'),
+    extras_require=get_extra_requirements(HERE / 'extra-requirements.txt'),
     entry_points={
         'console_scripts': [
             'dcTMD = dcTMD.__main__:main',


### PR DESCRIPTION
Runtime dependencies were previously declared only in the install_requires list of setup.py. Move them into a top-level requirements.txt and have setup.py read that file. Update the README.

Addresses point 1 of the review by @jkrajniak and point 1 by @chrisjonesBSU in openjournals/joss-reviews#10244.